### PR TITLE
Extending Cover block

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 ## Change log
 
+### 1.1.0 - In Development
+* Dev - Extend Gutenberg Core blocks with LSX attributes.
+
 ### 1.0.5 - 19 December 2019
 * Dev - General testing to ensure compatibility with latest WordPress version (5.3).
 * Dev - Checking compatibility with LSX 2.6 release.

--- a/classes/class-setup.php
+++ b/classes/class-setup.php
@@ -83,6 +83,11 @@ class Setup {
 		 * Load Gutenberg Group Block Styles
 		 */
 		require_once LSX_BLOCKS_PATH . 'src/extensions/block-group/index.php';
+
+		/**
+		 * Load Gutenberg Cover Block Styles
+		 */
+		require_once LSX_BLOCKS_PATH . 'src/extensions/block-cover/index.php';
 	}
 
 	/**

--- a/dist/blocks.style.build.css
+++ b/dist/blocks.style.build.css
@@ -2686,7 +2686,8 @@
   letter-spacing: 0.54px;
   line-height: 1.25;
   text-transform: uppercase;
-  background-color: currentColor; }
+  padding: 15px 40px;
+  background-color: #418ad0; }
 
 .wp-block-button {
   margin: 0 0 1em 0; }
@@ -2846,3 +2847,134 @@
     margin-top: 3rem; }
   .wp-block-group.is-style-lsx-group-style .wp-block-group__inner-container p.has-small-font-size {
     margin-bottom: 2rem; }
+/**
+ * Common styles
+ * Loads on front end and back end
+ */
+/* Font size styles */
+@media only screen and (min-width: 600px) {
+  div[class*="wp-block-lsx"].lsx-font-size-14.lsx-block-testimonial p,
+  div[class*="wp-block-lsx"].lsx-font-size-14.lsx-block-notice p,
+  div[class*="wp-block-lsx"].lsx-font-size-14.lsx-block-profile p,
+  div[class*="wp-block-lsx"].lsx-font-size-14.lsx-block-accordion p,
+  div[class*="wp-block-lsx"].lsx-font-size-14.lsx-block-cta p {
+    font-size: 14px; }
+  div[class*="wp-block-lsx"].lsx-font-size-15.lsx-block-testimonial p,
+  div[class*="wp-block-lsx"].lsx-font-size-15.lsx-block-notice p,
+  div[class*="wp-block-lsx"].lsx-font-size-15.lsx-block-profile p,
+  div[class*="wp-block-lsx"].lsx-font-size-15.lsx-block-accordion p,
+  div[class*="wp-block-lsx"].lsx-font-size-15.lsx-block-cta p {
+    font-size: 15px; }
+  div[class*="wp-block-lsx"].lsx-font-size-16.lsx-block-testimonial p,
+  div[class*="wp-block-lsx"].lsx-font-size-16.lsx-block-notice p,
+  div[class*="wp-block-lsx"].lsx-font-size-16.lsx-block-profile p,
+  div[class*="wp-block-lsx"].lsx-font-size-16.lsx-block-accordion p,
+  div[class*="wp-block-lsx"].lsx-font-size-16.lsx-block-cta p {
+    font-size: 16px; }
+  div[class*="wp-block-lsx"].lsx-font-size-17.lsx-block-testimonial p,
+  div[class*="wp-block-lsx"].lsx-font-size-17.lsx-block-notice p,
+  div[class*="wp-block-lsx"].lsx-font-size-17.lsx-block-profile p,
+  div[class*="wp-block-lsx"].lsx-font-size-17.lsx-block-accordion p,
+  div[class*="wp-block-lsx"].lsx-font-size-17.lsx-block-cta p {
+    font-size: 17px; }
+  div[class*="wp-block-lsx"].lsx-font-size-18.lsx-block-testimonial p,
+  div[class*="wp-block-lsx"].lsx-font-size-18.lsx-block-notice p,
+  div[class*="wp-block-lsx"].lsx-font-size-18.lsx-block-profile p,
+  div[class*="wp-block-lsx"].lsx-font-size-18.lsx-block-accordion p,
+  div[class*="wp-block-lsx"].lsx-font-size-18.lsx-block-cta p {
+    font-size: 18px; }
+  div[class*="wp-block-lsx"].lsx-font-size-19.lsx-block-testimonial p,
+  div[class*="wp-block-lsx"].lsx-font-size-19.lsx-block-notice p,
+  div[class*="wp-block-lsx"].lsx-font-size-19.lsx-block-profile p,
+  div[class*="wp-block-lsx"].lsx-font-size-19.lsx-block-accordion p,
+  div[class*="wp-block-lsx"].lsx-font-size-19.lsx-block-cta p {
+    font-size: 19px; }
+  div[class*="wp-block-lsx"].lsx-font-size-20.lsx-block-testimonial p,
+  div[class*="wp-block-lsx"].lsx-font-size-20.lsx-block-notice p,
+  div[class*="wp-block-lsx"].lsx-font-size-20.lsx-block-profile p,
+  div[class*="wp-block-lsx"].lsx-font-size-20.lsx-block-accordion p,
+  div[class*="wp-block-lsx"].lsx-font-size-20.lsx-block-cta p {
+    font-size: 20px; }
+  div[class*="wp-block-lsx"].lsx-font-size-21.lsx-block-testimonial p,
+  div[class*="wp-block-lsx"].lsx-font-size-21.lsx-block-notice p,
+  div[class*="wp-block-lsx"].lsx-font-size-21.lsx-block-profile p,
+  div[class*="wp-block-lsx"].lsx-font-size-21.lsx-block-accordion p,
+  div[class*="wp-block-lsx"].lsx-font-size-21.lsx-block-cta p {
+    font-size: 21px; }
+  div[class*="wp-block-lsx"].lsx-font-size-22.lsx-block-testimonial p,
+  div[class*="wp-block-lsx"].lsx-font-size-22.lsx-block-notice p,
+  div[class*="wp-block-lsx"].lsx-font-size-22.lsx-block-profile p,
+  div[class*="wp-block-lsx"].lsx-font-size-22.lsx-block-accordion p,
+  div[class*="wp-block-lsx"].lsx-font-size-22.lsx-block-cta p {
+    font-size: 22px; }
+  div[class*="wp-block-lsx"].lsx-font-size-23.lsx-block-testimonial p,
+  div[class*="wp-block-lsx"].lsx-font-size-23.lsx-block-notice p,
+  div[class*="wp-block-lsx"].lsx-font-size-23.lsx-block-profile p,
+  div[class*="wp-block-lsx"].lsx-font-size-23.lsx-block-accordion p,
+  div[class*="wp-block-lsx"].lsx-font-size-23.lsx-block-cta p {
+    font-size: 23px; }
+  div[class*="wp-block-lsx"].lsx-font-size-24.lsx-block-testimonial p,
+  div[class*="wp-block-lsx"].lsx-font-size-24.lsx-block-notice p,
+  div[class*="wp-block-lsx"].lsx-font-size-24.lsx-block-profile p,
+  div[class*="wp-block-lsx"].lsx-font-size-24.lsx-block-accordion p,
+  div[class*="wp-block-lsx"].lsx-font-size-24.lsx-block-cta p {
+    font-size: 24px; } }
+
+.center {
+  text-align: center; }
+
+.left {
+  text-align: left; }
+
+.right {
+  text-align: right; }
+
+@media only screen and (min-width: 600px) {
+  .wp-block-columns .layout-column-1,
+  .wp-block-columns .layout-column-2 {
+    margin-right: 5%; } }
+
+.wp-block-image {
+  margin-bottom: 1.2em; }
+
+.lsx-text-link {
+  color: inherit;
+  -webkit-box-shadow: 0 -1px 0 inset;
+          box-shadow: 0 -1px 0 inset;
+  text-decoration: none;
+  -webkit-transition: .3s ease;
+  -o-transition: .3s ease;
+  transition: .3s ease; }
+  .lsx-text-link:hover {
+    color: inherit;
+    -webkit-box-shadow: 0 -2px 0 inset;
+            box-shadow: 0 -2px 0 inset;
+    color: #27639e; }
+
+.lsx-button {
+  font-weight: 700;
+  text-transform: uppercase; }
+  .lsx-button:active {
+    left: 2px;
+    top: 2px;
+    position: relative; }
+
+.wp-block-cover.is-style-lsx-cover-style .wp-block-cover__inner-container {
+  max-width: 75%;
+  color: white;
+  text-align: center; }
+  .wp-block-cover.is-style-lsx-cover-style .wp-block-cover__inner-container .wp-block-image {
+    margin-bottom: 0; }
+    .wp-block-cover.is-style-lsx-cover-style .wp-block-cover__inner-container .wp-block-image img {
+      max-height: 95px;
+      margin: 0.5em auto;
+      max-width: 95px; }
+  .wp-block-cover.is-style-lsx-cover-style .wp-block-cover__inner-container h2 {
+    font-size: 40px;
+    padding-bottom: 0.2em;
+    line-height: 1em;
+    margin-bottom: 0; }
+  .wp-block-cover.is-style-lsx-cover-style .wp-block-cover__inner-container p {
+    font-size: 26px;
+    margin-bottom: 0.5em;
+    line-height: 1.2em; }

--- a/src/blocks.js
+++ b/src/blocks.js
@@ -13,7 +13,10 @@ import './blocks/block-card/index.js';
 import './blocks/block-banner/index.js';
 import './blocks/block-post-carousel/index.js';
 
+
+//Extensions
 import './extensions/block-image/spacing-control.js';
 import './extensions/block-column/padding-control.js';
 import './extensions/block-button/background-control.js';
 import './extensions/block-group/group-control.js';
+import './extensions/block-cover/cover-control.js';

--- a/src/extensions/block-button/styles/style.scss
+++ b/src/extensions/block-button/styles/style.scss
@@ -5,7 +5,8 @@
 	letter-spacing: 0.54px;
 	line-height: 1.25;
 	text-transform: uppercase;
-	background-color: currentColor;
+	padding: 15px 40px;
+	background-color: $blue;
 }
 .wp-block-button {
 	margin: 0 0 1em 0;

--- a/src/extensions/block-cover/cover-control.js
+++ b/src/extensions/block-cover/cover-control.js
@@ -1,0 +1,249 @@
+// Import CSS
+import './styles/style.scss';
+
+import assign from 'lodash.assign';
+
+const { __ } = wp.i18n;
+
+const { addFilter } = wp.hooks;
+
+//const { registerBlockStyle } = wp.blocks;
+const { createHigherOrderComponent } = wp.compose;
+const { Fragment } = wp.element;
+const { InspectorControls } = wp.blockEditor;
+const { PanelBody, RangeControl } = wp.components;
+
+// Enable spacing control on the following blocks
+const enableCustomCover = [
+	'core/cover',
+];
+
+/**
+ * Add the attributes to the cover
+ *
+ * @param {*} settings
+ * @param {*} name
+ * @returns
+ */
+function addCoverControlAttributes ( settings, name ) {
+	// Do nothing if it's another block than our defined ones.
+	if ( ! enableCustomCover.includes( name ) ) {
+		return settings;
+	}
+	settings.attributes = assign( settings.attributes, {
+		align: {
+			default: 'full',
+		},
+		dimRatio: {
+			default: 0,
+		},
+		coverPaddingTop: {
+			type: 'number',
+		},
+		coverPaddingBottom: {
+			type: 'number',
+		},
+		coverPaddingLeft: {
+			type: 'number',
+		},
+		coverPaddingRight: {
+			type: 'number',
+		},
+		coverMarginTop: {
+			type: 'number',
+		},
+		coverMarginBottom: {
+			type: 'number',
+		},
+		coverMarginLeft: {
+			type: 'number',
+		},
+		coverMarginRight: {
+			type: 'number',
+		},
+	} );
+
+	return settings;
+}
+addFilter(
+	'blocks.registerBlockType',
+	'lsx-blocks/extend-cover-block/cover-control-attribute',
+	addCoverControlAttributes
+);
+
+/**
+ * Create the Margin and Padding controls on the inspector controls of block.
+ */
+const coverSettingsControl = createHigherOrderComponent( ( BlockEdit ) => {
+	return ( props ) => {
+		// Do nothing if it's another block than our defined ones.
+		if ( ! enableCustomCover.includes( props.name ) ) {
+			return (
+				<BlockEdit { ...props } />
+			);
+		}
+
+		const { coverPaddingTop, coverPaddingBottom, coverPaddingLeft, coverPaddingRight, coverMarginTop, coverMarginBottom, coverMarginLeft, coverMarginRight } = props.attributes;
+
+		return (
+			<Fragment>
+				<BlockEdit { ...props } />
+				<InspectorControls>
+					<PanelBody
+						title={ __( 'Additional LSX Settings' ) }
+						initialOpen={ true }
+					>
+						<RangeControl
+							label={ __( 'Cover Padding Top (px)' ) }
+							value={ coverPaddingTop }
+							onChange={ ( value ) => props.setAttributes( { coverPaddingTop: value } ) }
+							min={ 0 }
+							max={ 100 }
+							step={ 1 }
+						/>
+						<RangeControl
+							label={ __( 'Cover Padding Bottom (px)' ) }
+							value={ coverPaddingBottom }
+							onChange={ ( value ) => props.setAttributes( { coverPaddingBottom: value } ) }
+							min={ 0 }
+							max={ 100 }
+							step={ 1 }
+						/>
+						<RangeControl
+							label={ __( 'Cover Padding Left (px)' ) }
+							value={ coverPaddingLeft }
+							onChange={ ( value ) => props.setAttributes( { coverPaddingLeft: value } ) }
+							min={ 0 }
+							max={ 100 }
+							step={ 1 }
+						/>
+						<RangeControl
+							label={ __( 'Cover Padding Right (px)' ) }
+							value={ coverPaddingRight }
+							onChange={ ( value ) => props.setAttributes( { coverPaddingRight: value } ) }
+							min={ 0 }
+							max={ 100 }
+							step={ 1 }
+						/>
+						<RangeControl
+							label={ __( 'Cover Margin Top (px)' ) }
+							value={ coverMarginTop }
+							onChange={ ( value ) => props.setAttributes( { coverMarginTop: value } ) }
+							min={ 0 }
+							max={ 100 }
+							step={ 1 }
+						/>
+						<RangeControl
+							label={ __( 'Cover Margin Bottom (px)' ) }
+							value={ coverMarginBottom }
+							onChange={ ( value ) => props.setAttributes( { coverMarginBottom: value } ) }
+							min={ 0 }
+							max={ 100 }
+							step={ 1 }
+						/>
+						<RangeControl
+							label={ __( 'Cover Margin Left (px)' ) }
+							value={ coverMarginLeft }
+							onChange={ ( value ) => props.setAttributes( { coverMarginLeft: value } ) }
+							min={ 0 }
+							max={ 100 }
+							step={ 1 }
+						/>
+						<RangeControl
+							label={ __( 'Cover Margin Right (px)' ) }
+							value={ coverMarginRight }
+							onChange={ ( value ) => props.setAttributes( { coverMarginRight: value } ) }
+							min={ 0 }
+							max={ 100 }
+							step={ 1 }
+						/>
+					</PanelBody>
+				</InspectorControls>
+			</Fragment>
+		);
+	};
+}, 'coverSettingsControl' );
+
+addFilter(
+	'editor.BlockEdit',
+	'lsx-blocks/extend-cover-block/cover-settings-control',
+	coverSettingsControl
+);
+
+/**
+ * Add all styles attributes to the element block.
+ *
+ * @param {object} saveElementProps Props of save element.
+ * @param {Object} blockType Block type information.
+ * @param {Object} attributes Attributes of block.
+ *
+ * @returns {object} Modified props of save element.
+ */
+const addExtraPropsCover = ( saveElementProps, blockType, attributes ) => {
+
+	// Do nothing if it's another block than our defined ones.
+	if ( ! enableCustomCover.includes( blockType.name ) ) {
+		return saveElementProps;
+	}
+
+	if ( blockType.name === 'core/cover' ) {
+
+		let paddingTop = attributes.coverPaddingTop + 'px';
+		let paddingBottom = attributes.coverPaddingBottom + 'px';
+		let paddingLeft = attributes.coverPaddingLeft + 'px';
+		let paddingRight = attributes.coverPaddingRight + 'px';
+		let marginTop = attributes.coverMarginTop + 'px';
+		let marginBottom = attributes.coverMarginBottom + 'px';
+		let marginLeft = attributes.coverMarginLeft + 'px';
+		let marginRight = attributes.coverMarginRight + 'px';
+
+		let str = '';
+		let style = '';
+		var obj2 = '';
+		if ( undefined !== attributes.coverPaddingTop ) {
+			var obj2 = { ...obj2, 'paddingTop': paddingTop };
+		}
+		if ( undefined !== attributes.coverPaddingBottom ) {
+			var obj2 = { ...obj2, 'paddingBottom': paddingBottom };
+		}
+		if ( undefined !== attributes.coverPaddingLeft ) {
+			var obj2 = { ...obj2, 'paddingLeft': paddingLeft };
+		}
+		if ( undefined !== attributes.coverPaddingRight ) {
+			var obj2 = { ...obj2, 'paddingRight': paddingRight };
+		}
+		if ( undefined !== attributes.coverMarginTop ) {
+			var obj2 = { ...obj2, 'marginTop': marginTop };
+		}
+		if ( undefined !== attributes.coverMarginBottom ) {
+			var obj2 = { ...obj2, 'marginBottom': marginBottom };
+		}
+		if ( undefined !== attributes.coverMarginLeft ) {
+			var obj2 = { ...obj2, 'marginLeft': marginLeft };
+		}
+		if ( undefined !== attributes.coverMarginRight ) {
+			var obj2 = { ...obj2, 'marginRight': marginRight };
+		}
+
+		str = saveElementProps.style;
+
+		style = { ...str, ...obj2 };
+
+
+		// console.log(saveElementProps);
+		// console.log(attributes);
+
+		assign( saveElementProps,
+			{ style },
+		);
+	}
+
+	return saveElementProps;
+
+};
+
+addFilter(
+	'blocks.getSaveContent.extraProps',
+	'lsx-blocks/extend-cover-block/add-extra-props-cover',
+	addExtraPropsCover
+);

--- a/src/extensions/block-cover/index.php
+++ b/src/extensions/block-cover/index.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Register Custom Block Styles for Cover
+ *
+ * @package LSX BLOCKS
+ */
+
+if ( function_exists( 'register_block_style' ) ) {
+	/**
+	 * Register Custom Block Styles for Cover
+	 *
+	 * @return void
+	 */
+	function block_styles_register_cover_block_styles() {
+
+		/**
+		 * Register block style
+		 */
+		register_block_style(
+			'core/cover',
+			array(
+				'name'      => 'lsx-cover-style',
+				'label'     => __( 'LSX Banner' ),
+				'isDefault' => true,
+			)
+		);
+	}
+
+	add_action( 'init', 'block_styles_register_cover_block_styles' );
+}

--- a/src/extensions/block-cover/styles/style.scss
+++ b/src/extensions/block-cover/styles/style.scss
@@ -1,0 +1,28 @@
+.wp-block-cover {
+	&.is-style-lsx-cover-style {
+		.wp-block-cover__inner-container {
+			max-width: 75%;
+			color: white;
+			text-align: center;
+			.wp-block-image {
+				margin-bottom: 0;
+				img {
+					max-height: 95px;
+					margin: 0.5em auto;
+					max-width: 95px;
+				};
+			}
+			h2 {
+				font-size: 40px;
+				padding-bottom: 0.2em;
+				line-height: 1em;
+				margin-bottom: 0;
+			}
+			p {
+				font-size: 26px;
+				margin-bottom: 0.5em;
+				line-height: 1.2em;
+			}
+		}
+	}
+}

--- a/src/extensions/block-group/group-control.js
+++ b/src/extensions/block-group/group-control.js
@@ -88,7 +88,7 @@ const groupSettingsControl = createHigherOrderComponent( ( BlockEdit ) => {
 						initialOpen={ true }
 					>
 						<RangeControl
-							label={ __( 'Group Padding Top' ) }
+							label={ __( 'Group Padding Top (px)' ) }
 							value={ groupPaddingTop }
 							onChange={ ( value ) => props.setAttributes( { groupPaddingTop: value } ) }
 							min={ 0 }
@@ -96,7 +96,7 @@ const groupSettingsControl = createHigherOrderComponent( ( BlockEdit ) => {
 							step={ 1 }
 						/>
 						<RangeControl
-							label={ __( 'Group Padding Bottom' ) }
+							label={ __( 'Group Padding Bottom (px)' ) }
 							value={ groupPaddingBottom }
 							onChange={ ( value ) => props.setAttributes( { groupPaddingBottom: value } ) }
 							min={ 0 }
@@ -104,7 +104,7 @@ const groupSettingsControl = createHigherOrderComponent( ( BlockEdit ) => {
 							step={ 1 }
 						/>
 						<RangeControl
-							label={ __( 'Group Padding Left' ) }
+							label={ __( 'Group Padding Left (px)' ) }
 							value={ groupPaddingLeft }
 							onChange={ ( value ) => props.setAttributes( { groupPaddingLeft: value } ) }
 							min={ 0 }
@@ -112,7 +112,7 @@ const groupSettingsControl = createHigherOrderComponent( ( BlockEdit ) => {
 							step={ 1 }
 						/>
 						<RangeControl
-							label={ __( 'Group Padding Right' ) }
+							label={ __( 'Group Padding Right (px)' ) }
 							value={ groupPaddingRight }
 							onChange={ ( value ) => props.setAttributes( { groupPaddingRight: value } ) }
 							min={ 0 }
@@ -120,7 +120,7 @@ const groupSettingsControl = createHigherOrderComponent( ( BlockEdit ) => {
 							step={ 1 }
 						/>
 						<RangeControl
-							label={ __( 'Group Margin Top' ) }
+							label={ __( 'Group Margin Top (px)' ) }
 							value={ groupMarginTop }
 							onChange={ ( value ) => props.setAttributes( { groupMarginTop: value } ) }
 							min={ 0 }
@@ -128,7 +128,7 @@ const groupSettingsControl = createHigherOrderComponent( ( BlockEdit ) => {
 							step={ 1 }
 						/>
 						<RangeControl
-							label={ __( 'Group Margin Bottom' ) }
+							label={ __( 'Group Margin Bottom (px)' ) }
 							value={ groupMarginBottom }
 							onChange={ ( value ) => props.setAttributes( { groupMarginBottom: value } ) }
 							min={ 0 }
@@ -136,7 +136,7 @@ const groupSettingsControl = createHigherOrderComponent( ( BlockEdit ) => {
 							step={ 1 }
 						/>
 						<RangeControl
-							label={ __( 'Group Margin Left' ) }
+							label={ __( 'Group Margin Left (px)' ) }
 							value={ groupMarginLeft }
 							onChange={ ( value ) => props.setAttributes( { groupMarginLeft: value } ) }
 							min={ 0 }
@@ -144,7 +144,7 @@ const groupSettingsControl = createHigherOrderComponent( ( BlockEdit ) => {
 							step={ 1 }
 						/>
 						<RangeControl
-							label={ __( 'Group Margin Right' ) }
+							label={ __( 'Group Margin Right (px)' ) }
 							value={ groupMarginRight }
 							onChange={ ( value ) => props.setAttributes( { groupMarginRight: value } ) }
 							min={ 0 }


### PR DESCRIPTION
**Description**

This branch extend the Cover Block to replace the LSX Banner Block, it adds spacing options and a block style to make it look like an LSX banner by default.

**What it does**
- Adds margin options 
- Adds padding options
- Adds a block style `is-style-lsx-cover-style` to center content and make the spacing like an LSX banner

This block will fully replace LSX Hero Banner block.