### PR TITLE
making sure the Disable Title metabox only appears on posts, when the…

### DIFF
--- a/classes/class-admin.php
+++ b/classes/class-admin.php
@@ -33,7 +33,7 @@ class Admin {
 	 * @access private
 	 */
 	private function __construct() {
-		add_action( 'add_meta_boxes', array( $this, 'featured_meta' ) );
+		add_action( 'add_meta_boxes_post', array( $this, 'featured_meta' ) );
 		add_action( 'save_post', array( $this, 'meta_save' ) );
 	}
 
@@ -56,14 +56,16 @@ class Admin {
 	 * Adds a meta box to the post editing screen
 	 */
 	public function featured_meta() {
-		add_meta_box(
-			'lsx_blocks_title_meta',
-			__( 'Disable Title', 'lsx-blocks' ),
-			array( $this, 'meta_callback' ),
-			null,
-			'side',
-			'high'
-		);
+		if ( use_block_editor_for_post( get_the_ID() ) ) {
+			add_meta_box(
+				'lsx_blocks_title_meta',
+				__( 'Disable Title', 'lsx-blocks' ),
+				array( $this, 'meta_callback' ),
+				null,
+				'side',
+				'high'
+			);
+		}
 	}
 
 

--- a/classes/class-frontend.php
+++ b/classes/class-frontend.php
@@ -96,7 +96,7 @@ class Frontend {
 	 */
 	public function disable_lsx_page_title( $disable ) {
 		$disable_title = get_post_meta( get_the_ID(), 'lsx_disable_title', true );
-		if ( 'yes' === $disable_title ) {
+		if ( 'yes' === $disable_title && is_singular( 'post' ) ) {
 			$disable = true;
 		}
 		return $disable;


### PR DESCRIPTION
### Description of the Change

This fix is to make sure the `page-has-banner` body class is properly set, and to make sure that the 'Disable Title' meta box is working correctly on posts that are edited with the block editor.

### Benefits

This will allow older posts that are edited with the block editor to have the banner easily enabled or disabled.

### Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.

### Applicable Issues

https://github.com/lightspeeddevelopment/lsx/issues/334
https://github.com/lightspeeddevelopment/lsx/pull/335
