### PR TITLE
Fixing where the page title output

### DIFF
--- a/classes/lib/class-page-title.php
+++ b/classes/lib/class-page-title.php
@@ -84,6 +84,10 @@ class Page_Title {
 		$position = apply_filters( 'lsx_hero_banner_block_position', $position );
 		switch ( $position ) {
 			case 'below-banner':
+				add_action( 'lsx_content_top', array( $this, 'lsx_block_header' ) );
+				break;
+
+			case 'above-content':
 				add_action( 'lsx_entry_top', array( $this, 'lsx_block_header' ) );
 				break;
 


### PR DESCRIPTION
### Description
The output of the page title below the banner has been fixed. And a new option to display the title above the content has been added.

In Banner
![Screenshot 2020-07-06 at 13 50 36](https://user-images.githubusercontent.com/1805603/86590523-106d0f00-bf90-11ea-89a1-f90c308c9b84.png)

Below Banner
![Screenshot 2020-07-06 at 13 50 13](https://user-images.githubusercontent.com/1805603/86590536-1367ff80-bf90-11ea-84b8-18ea3601b426.png)

Above Content
![Screenshot 2020-07-06 at 13 49 24](https://user-images.githubusercontent.com/1805603/86590543-15ca5980-bf90-11ea-95ef-2fa09189c852.png)
