### PR TITLE
Making sure that the page title class is added only when the page title is on

### DIFF
--- a/classes/lib/class-page-title.php
+++ b/classes/lib/class-page-title.php
@@ -74,7 +74,7 @@ class Page_Title {
 	}
 
 	/**
-	 * Adds our page title class to the body
+	 * Position our page title class on the body
 	 *
 	 * @param  array $classes
 	 * @return array
@@ -96,8 +96,6 @@ class Page_Title {
 				add_action( 'lsx_hero_banner', array( $this, 'lsx_block_header' ) );
 				break;
 		}
-		$classes[] = 'lsx-page-title';
-		return $classes;
 	}
 
 	/**
@@ -107,6 +105,29 @@ class Page_Title {
 	 * @return array
 	 */
 	public function body_class( $classes ) {
+
+		$disable_title = get_post_meta( get_the_ID(), 'lsx_disable_title', true );
+		if ( 'yes' !== $disable_title || ( ! is_singular() ) ) {
+			return $classes;
+		}
+
+		$position = get_post_meta( get_the_ID(), 'lsx_title_position', true );
+		$position = apply_filters( 'lsx_hero_banner_block_position', $position );
+		switch ( $position ) {
+			case 'below-banner':
+				add_action( 'lsx_content_top', array( $this, 'lsx_block_header' ) );
+				break;
+
+			case 'above-content':
+				add_action( 'lsx_entry_top', array( $this, 'lsx_block_header' ) );
+				break;
+
+			case 'in-banner':
+			default:
+				add_action( 'lsx_hero_banner', array( $this, 'lsx_block_header' ) );
+				break;
+		}
+		$classes[] = 'lsx-title-' . $position;
 		$classes[] = 'lsx-page-title';
 		return $classes;
 	}


### PR DESCRIPTION
### Description of the Change

Making sure that the page title class is added only when the page title is enabled.
This way it wont add an extra margin coming from that `lsx-page-title` body class

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.
